### PR TITLE
feat(yunohost): Use the main repository as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ request the repo's url with in the header `Repository-Key : <value of the key>` 
 
 On yeswiki core or loginldap update, if the YunoHost package is not up to date, a new branch will be created on the `yunohost-git` repository with updated version number and hash.
 
-For that to work, there should be a commiter known to git, at least for that repository. It can be added via `git config --global user.email "an-email@here"` and `git config --global "Username"`.
+For that to work, there should be a commiter known to git, at least for that repository. It can be added via `git config --global user.email "an-email@here"` and `git config --global user.name "Username"`.
 
 It will need manual action for a PR to be created against [YunoHost-Apps/yeswiki_ynh](https://github.com/YunoHost-Apps/yeswiki_ynh) and any member of the YunoHost-Apps org will be able to run the ynh CI on it.


### PR DESCRIPTION
This commit adds the YunoHost-Apps repository as the source of up to
date versions of the app.

It still pushes to the configured repository, to allow anyone to use
this script, not relying on push access to YunoHost-Apps/yeswiki_ynh

Par contre, je ne sais pas trop comment intégrer le fait que @mrflos ne veut pas qu'il y ait une branche par version, puisqu'actuellement, c'est la présence de la branche qui est vérifiée pour savoir si les modifications ont déjà été faites.