### PR TITLE
Some improvements

### DIFF
--- a/app/PackageBuilder.php
+++ b/app/PackageBuilder.php
@@ -35,7 +35,7 @@ class PackageBuilder
         $this->composer($srcFile);
  
         // For the core YesWiki, change YesWiki version in the files
-        if ($pkgInfos['repository'] == 'https://github.com/YesWiki/yeswiki') {
+        if (substr($pkgName, 0, strlen("yeswiki-")) == "yeswiki-") {
             $yeswikiVersion = $pkgInfos['branch'] = str_replace('yeswiki-', '', $pkgName);
             $file = file_get_contents($srcFile.'/includes/constants.php');
             $file = preg_replace('/define\("YESWIKI_VERSION", .*\);/Ui', 'define("YESWIKI_VERSION", \''.$yeswikiVersion.'\');', $file);

--- a/app/Repository.php
+++ b/app/Repository.php
@@ -245,12 +245,14 @@ class Repository
     {
         $destDir = getcwd().'/packages-src/'.basename($pkgInfos['repository']);
         $version = empty($pkgInfos['tag']) ? 'origin/'.$pkgInfos['branch'] : 'tags/'.$pkgInfos['tag'];
+        $localBranchOrTagName = empty($pkgInfos['tag']) ? $pkgInfos['branch'] : $pkgInfos['tag'];
         if (!is_dir($destDir)) {
             echo exec('git clone '.$pkgInfos['repository'].' '.$destDir."\n");
         } else {
             echo exec("cd $destDir; git remote set-url origin {$pkgInfos['repository']}")."\n";
         }
         echo exec('cd '.$destDir.'; git fetch --all --tags -f --prune')."\n";
+        echo exec("cd $destDir; git checkout {$localBranchOrTagName}")."\n";
         echo exec('cd '.$destDir.'; git reset --hard '.$version)."\n";
         return $destDir;
     }

--- a/app/Repository.php
+++ b/app/Repository.php
@@ -6,17 +6,20 @@ use \Exception;
 
 // Polyfills for php<8
 if (!function_exists('str_starts_with')) {
-    function str_starts_with($haystack, $needle) {
+    function str_starts_with($haystack, $needle)
+    {
         return (string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0;
     }
 }
 if (!function_exists('str_ends_with')) {
-    function str_ends_with($haystack, $needle) {
+    function str_ends_with($haystack, $needle)
+    {
         return $needle !== '' && substr($haystack, -strlen($needle)) === (string)$needle;
     }
 }
 if (!function_exists('str_contains')) {
-    function str_contains($haystack, $needle) {
+    function str_contains($haystack, $needle)
+    {
         return $needle !== '' && mb_strpos($haystack, $needle) !== false;
     }
 }
@@ -244,6 +247,8 @@ class Repository
         $version = empty($pkgInfos['tag']) ? 'origin/'.$pkgInfos['branch'] : 'tags/'.$pkgInfos['tag'];
         if (!is_dir($destDir)) {
             echo exec('git clone '.$pkgInfos['repository'].' '.$destDir."\n");
+        } else {
+            echo exec("cd $destDir; git remote set-url origin {$pkgInfos['repository']}")."\n";
         }
         echo exec('cd '.$destDir.'; git fetch --all --tags -f --prune')."\n";
         echo exec('cd '.$destDir.'; git reset --hard '.$version)."\n";

--- a/index.php
+++ b/index.php
@@ -5,7 +5,9 @@ namespace YesWikiRepo;
 $loader = require __DIR__ . '/vendor/autoload.php';
 
 set_exception_handler(function ($e) {
-    header('HTTP/1.1 500 Internal Server Error');
+    if (!isset($argv)) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     echo htmlSpecialChars($e->getMessage());
     die();
 });

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ if (isset($argv)) { // Command line
 if (!empty($_GET['action']) && in_array($_GET['action'], ['init','update', 'purge'])) { // HTTP Request
     $header = getallheaders();
 
-    if (isset($header['Repository-Key']) && $header['Repository-Key'] == $config['repo-key']) {
+    if (!empty($config['repo-key']) && isset($header['Repository-Key']) && $header['Repository-Key'] == $config['repo-key']) {
         (new ScriptController($repo))->run($_GET);
         exit;
     } else {


### PR DESCRIPTION
@mrflos J'ai quelques améliorations à te proposer sur le constructeur du dépôt. L'idée est d'éviter des warnings php et d'être sûr que les informations en provenance de `repo.config.json` sont bien prises en compte

Chaque commit explique le besoin:
 - [fix(index.php): allow to inactivate repo-key if empty](https://github.com/YesWiki/yeswiki-build-repo/commit/30f8ba7e5b3c4ac1da594a39cb82aeac86db2a26) (c'est pour éviter de laisser la porte ouverte à `purge` si le paramètre est vide et ça permet de ne pas activer la fonction par `$_GET` pour éviter les attaques par force brute sur `repo-key`)
 - [fix(Repository::getGitFolder): update repository remote address](https://github.com/YesWiki/yeswiki-build-repo/commit/17317c076c8804c25354ec1be5df391400e1bcd2)
 - [fix(index.php): remove warning when setting headers in command line mode](https://github.com/YesWiki/yeswiki-build-repo/commit/3765ae3c5e36fe1a3dec41a3c6d7dc24e0eac204)
 - [fix(PackageBuilder): do not depend on repository address](https://github.com/YesWiki/yeswiki-build-repo/commit/257d1f46c4c0c306a5680142566199847eecc823)
 - [fix(Repository): more stable branch name if different from main branch](https://github.com/YesWiki/yeswiki-build-repo/pull/14/commits/c496d39fd8b3638c374509ec786c173ba0418612)
 
 **Ce que ça ne fait pas**:
  - prendre en compte le paramètre `secret` des hooks github