### PR TITLE
feat(github-hook): manage secrets and make it work

### DIFF
--- a/app/PackageBuilder.php
+++ b/app/PackageBuilder.php
@@ -114,10 +114,17 @@ class PackageBuilder
         if (is_dir($path.'/vendor')) {
             (new File($path.'/vendor'))->delete($path.'/vendor');
         }
-        $command = $this->composerFile
-            . " install --no-progress --no-dev --optimize-autoloader --working-dir=";
+        $command = "{$this->composerFile} install --no-progress --no-dev --optimize-autoloader --working-dir=\"{path}\" 2>&1";
         if (file_exists($path.'/composer.json')) {
-            echo exec($command . '"' . $path . '"');
+            $output = null;
+            $retval = null;
+            $lastLine = exec(str_replace("{path}",$path,$command),$output, $retval);
+            foreach ($output as $lineNumber => $content) {
+                echo "$content\n";
+            }
+            if ($retval != 0){
+                throw new Exception("Trouble while starting 'composer' for ".basename($path));
+            }
         }
         // check if default extensions need some composer
         if (\is_dir($path.'/tools')) {
@@ -126,7 +133,15 @@ class PackageBuilder
                 if ($fileinfo->isDir() && ! $fileinfo->isDot()) {
                     $extFolder = $fileinfo->getPathname();
                     if (file_exists($extFolder.'/composer.json')) {
-                        echo exec($command . '"' . $extFolder . '"');
+                        $output = null;
+                        $retval = null;
+                        $lastLine = exec(str_replace("{path}",$extFolder,$command),$output, $retval);
+                        foreach ($output as $lineNumber => $content) {
+                            echo "$content\n";
+                        }
+                        if ($retval != 0){
+                            throw new Exception("Trouble while starting 'composer' for ".basename($path)."/tools/".basename($extFolder));
+                        }
                     }
                 }
             }

--- a/app/Repository.php
+++ b/app/Repository.php
@@ -121,7 +121,10 @@ class Repository
 
         foreach ($this->repoConf as $subRepoName => $packages) {
             foreach ($packages as $packageName => $packageInfos) {
-                if ($packageInfos['repository'] === $repositoryUrl
+                $waitedRepoUrl = (substr($packageInfos['repository'],-1) == "/")
+                    ? substr($packageInfos['repository'],0,-1) 
+                    : $packageInfos['repository'];
+                if ($waitedRepoUrl === $repositoryUrl
                     and $packageInfos['branch'] === $branch
                 ) {
                     $this->updatePackage($packageName, $packageInfos, $subRepoName);

--- a/app/Repository.php
+++ b/app/Repository.php
@@ -33,11 +33,23 @@ class Repository
 
     private $packageBuilder = null;
     private $doYnhUpdate = false;
+    private $exceptionPassThrough ; 
 
     public function __construct($configFile)
     {
         $this->packages = array();
         $this->localConf = $configFile;
+        $this->exceptionPassThrough = false;
+    }
+
+    public function activateExceptionPassThrough()
+    {
+        $this->exceptionPassThrough = true;
+    }
+
+    public function inactivateExceptionPassThrough()
+    {
+        $this->exceptionPassThrough = false;
     }
 
     public function load()
@@ -129,6 +141,10 @@ class Repository
                 ) {
                     $this->updatePackage($packageName, $packageInfos, $subRepoName);
                 }
+            }
+            if (!file_exists($this->localConf['repo-path'] . $subRepoName . '/packages.json')) {
+                // Créé le fichier d'index.
+                $this->actualState[$subRepoName]->write();
             }
         }
 
@@ -246,6 +262,9 @@ class Repository
     {
         syslog(LOG_INFO, "Building $packageName...");
         if ($this->packageBuilder === null) {
+            if (!empty($this->localConf['home-dir'])){
+                putenv("HOME={$this->localConf['home-dir']}");
+            }
             $this->packageBuilder = new PackageBuilder(
                 $this->localConf['composer-bin']
             );
@@ -262,6 +281,9 @@ class Repository
                 LOG_ERR,
                 "Failed building $packageName : " . $e->getMessage()
             );
+            if ($this->exceptionPassThrough){
+                throw $e;
+            }
             return false;
         }
         syslog(LOG_INFO, "$packageName has been built...");

--- a/app/WebhookController.php
+++ b/app/WebhookController.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace YesWikiRepo;
 
-use \Exception;
+use Exception;
 
 class WebhookController extends Controller
 {
@@ -9,22 +10,39 @@ class WebhookController extends Controller
     {
         $this->repo->load();
         $this->repo->updateHook(
-            $this->getRepository($params) . '/',
+            $this->getRepository($params),
             $this->getBranch($params)
+        );
+    }
+
+    public function isAuthorizedHook(): bool
+    {
+        $header = getallheaders();
+        $content = file_get_contents('php://input');
+        return (!empty($this->repo->localConf['github-secret']) &&
+            isset($header['X-Hub-Signature-256']) &&
+            function_exists('hash_hmac') &&
+            $header['X-Hub-Signature-256'] == 'sha256='.hash_hmac('sha256', $content, $this->repo->localConf['github-secret'])
         );
     }
 
     private function getBranch($params)
     {
-        $explodedRef = explode('/', $params['ref']);
-        return end($explodedRef);
+        if (empty($params['ref'])) {
+            throw new Exception("'ref' should be set !");
+        }
+        if (!is_string($params['ref'])) {
+            throw new Exception("'ref' should be a string !");
+        }
+        return substr($params['ref'], strlen('refs/heads/'));
     }
 
     private function getRepository($params)
     {
-        if (isset($params['repository']['html_url'])) {
-            return $params['repository']['html_url'];
+        if (isset($params['repository']) && isset($params['repository']['html_url'])) {
+            $repoUrl = $params['repository']['html_url'];
+            return substr($repoUrl,-1) == '/' ? substr($repoUrl,0,-1) : $repoUrl;
         }
-        throw new Exception("Bad hook format.", 1);
+        throw new Exception("Bad hook format.");
     }
 }

--- a/app/WebhookController.php
+++ b/app/WebhookController.php
@@ -9,10 +9,12 @@ class WebhookController extends Controller
     public function run($params)
     {
         $this->repo->load();
+        $this->repo->activateExceptionPassThrough();
         $this->repo->updateHook(
             $this->getRepository($params),
             $this->getBranch($params)
         );
+        $this->repo->inactivateExceptionPassThrough();
     }
 
     public function isAuthorizedHook(): bool

--- a/config.php.example
+++ b/config.php.example
@@ -15,4 +15,5 @@ $config = [
   "yunohost-subRepo" => "doryphore",
   "yunohost-git" => "https://user:http_push_token@github.com/YesWiki/yeswiki_ynh",
   "yunohost-git-source-branch" => "testing",
+  // "github-secret" => 'change this',
 ];

--- a/config.php.example
+++ b/config.php.example
@@ -6,6 +6,7 @@ $config = [
   "repo-url" => "https://repository.yeswiki.net",
   "mail-to" => "change.my@mail.net",
   "composer-bin" => "/usr/local/bin/composer",
+  //"home-dir" => "/usr/local/bin/composer", // to fill if HOME is not defined for webhook
   "repo-key" => 'change this',
   "mattermost-hook-url" => "https://mattermostserver.ext/hooks/yourhookkey",
   "mattermost-channel" => 'repository',


### PR DESCRIPTION
Je propose cette PR pour rendre fonctionnel la génération automatique d'une nouvelle release à partir d'un webhook GitHub.
Au passage, je sécurise le fonctionnement en obligeant à ce que `github-secret` soit défini et évite ainsi des `ping` non sollicités.

Qu'en dis-tu @mrflos ? Je commence à tester ceci sur mon dépôt pour voir.

NB : je n'ai pas poussé trop loin le refactor car n'étant pas dans l'environnement YesWiki, il y a moins de librairies déjà installées pour aider à le faire.